### PR TITLE
Add minus key mapping to keyboard utils

### DIFF
--- a/templates/python/computer-use/tools/computer.py
+++ b/templates/python/computer-use/tools/computer.py
@@ -45,6 +45,7 @@ KEY_MAP = {
     'escape': 'Escape',
     'insert': 'Insert',
     'super_l': 'Meta',
+    'minus': 'Minus',
     'f1': 'F1',
     'f2': 'F2',
     'f3': 'F3',

--- a/templates/typescript/computer-use/tools/utils/keyboard.ts
+++ b/templates/typescript/computer-use/tools/utils/keyboard.ts
@@ -11,6 +11,7 @@ export class KeyboardUtils {
   private static readonly keyMap: Record<string, string> = {
     'return': 'Enter',
     'space': ' ',
+    'minus': 'Minus',
     'left': 'ArrowLeft',
     'right': 'ArrowRight',
     'up': 'ArrowUp',


### PR DESCRIPTION
 Added `'minus': 'Minus'` mapping for xdotool to Playwright compatibility - Ensures minus key presses work correctly in claude computer use actions. 


Relevant link: https://playwright.dev/docs/input#keys-and-shortcuts

Fixes: https://github.com/onkernel/create-kernel-app/issues/22